### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = ""

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ REZ: 100~2000nt, 40% G
 
 ![screenshot](Screenshot1.png)
 ![screenshot](Screenshot2.png)
+
+[![Run on Repl.it](https://repl.it/badge/github/gatozee/rlfs-finder)](https://repl.it/github/gatozee/rlfs-finder)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).